### PR TITLE
refactor(backend): modularize router structure and clean up main

### DIFF
--- a/backend/internal/factories/handlers.go
+++ b/backend/internal/factories/handlers.go
@@ -1,0 +1,44 @@
+package factories
+
+import (
+	"certitrack/internal/config"
+	"certitrack/internal/handlers"
+	"certitrack/internal/repositories"
+	"certitrack/internal/services"
+
+	"gorm.io/gorm"
+)
+
+type AuthFactory struct {
+	db          *gorm.DB
+	cfg         *config.Config
+	userRepo    repositories.UserRepository
+	authService services.AuthService
+	authHandler *handlers.AuthHandler
+}
+
+var authFactory *AuthFactory
+
+func AuthFactoryInstance(db *gorm.DB, cfg *config.Config) *AuthFactory {
+	if authFactory == nil {
+		userRepo := repositories.NewUserRepositoryImpl(db)
+		authService := services.NewAuthService(cfg, userRepo)
+		authHandler := handlers.NewAuthHandler(authService)
+		authFactory = &AuthFactory{
+			db:          db,
+			cfg:         cfg,
+			userRepo:    userRepo,
+			authService: authService,
+			authHandler: authHandler,
+		}
+	}
+	return authFactory
+}
+
+func (f *AuthFactory) GetAuthHandler() *handlers.AuthHandler {
+	return f.authHandler
+}
+
+func (f *AuthFactory) GetAuthService() services.AuthService {
+	return f.authService
+}

--- a/backend/internal/router/auth.go
+++ b/backend/internal/router/auth.go
@@ -1,0 +1,30 @@
+package router
+
+import (
+	"certitrack/internal/config"
+	"certitrack/internal/factories"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+func setupAuthRoutes(rg *gin.RouterGroup, db *gorm.DB, cfg *config.Config) {
+	auth := rg.Group("/auth")
+	{
+		authFactory := factories.AuthFactoryInstance(db, cfg)
+		authHandler := authFactory.GetAuthHandler()
+
+		auth.POST("/login", authHandler.Login)
+		auth.POST("/register", authHandler.Register)
+		auth.POST("/refresh", authHandler.RefreshToken)
+		auth.POST("/logout", authHandler.Logout)
+	}
+}
+
+func setupProtectedAuthRoutes(rg *gin.RouterGroup, db *gorm.DB, cfg *config.Config) {
+	authFactory := factories.AuthFactoryInstance(db, cfg)
+	authHandler := authFactory.GetAuthHandler()
+
+	rg.GET("/profile", authHandler.GetProfile)
+	rg.POST("/change-password", authHandler.ChangePassword)
+}

--- a/backend/internal/router/certifications.go
+++ b/backend/internal/router/certifications.go
@@ -1,0 +1,34 @@
+package router
+
+import (
+	"certitrack/internal/config"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+func setupCertificationRoutes(rg *gin.RouterGroup, db *gorm.DB, cfg *config.Config) {
+	certifications := rg.Group("/certifications")
+	{
+		certifications.GET("", func(ctx *gin.Context) {
+			ctx.JSON(http.StatusOK, gin.H{"message": "Certifications"})
+		})
+		certifications.POST("", func(ctx *gin.Context) {
+			ctx.JSON(http.StatusOK, gin.H{"message": "Create Certification"})
+		})
+
+		certRoutes := certifications.Group("/:id")
+		{
+			certRoutes.GET("", func(ctx *gin.Context) {
+				ctx.JSON(http.StatusOK, gin.H{"message": "Get Certification"})
+			})
+			certRoutes.PUT("", func(ctx *gin.Context) {
+				ctx.JSON(http.StatusOK, gin.H{"message": "Update Certification"})
+			})
+			certRoutes.DELETE("", func(ctx *gin.Context) {
+				ctx.JSON(http.StatusOK, gin.H{"message": "Delete Certification"})
+			})
+		}
+	}
+}

--- a/backend/internal/router/equipment.go
+++ b/backend/internal/router/equipment.go
@@ -1,0 +1,34 @@
+package router
+
+import (
+	"certitrack/internal/config"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+func setupEquipmentRoutes(rg *gin.RouterGroup, db *gorm.DB, cfg *config.Config) {
+	equipment := rg.Group("/equipment")
+	{
+		equipment.GET("", func(ctx *gin.Context) {
+			ctx.JSON(http.StatusOK, gin.H{"message": "Equipment"})
+		})
+		equipment.POST("", func(ctx *gin.Context) {
+			ctx.JSON(http.StatusOK, gin.H{"message": "Create Equipment"})
+		})
+
+		equipmentRoutes := equipment.Group("/:id")
+		{
+			equipmentRoutes.GET("", func(ctx *gin.Context) {
+				ctx.JSON(http.StatusOK, gin.H{"message": "Get Equipment"})
+			})
+			equipmentRoutes.PUT("", func(ctx *gin.Context) {
+				ctx.JSON(http.StatusOK, gin.H{"message": "Update Equipment"})
+			})
+			equipmentRoutes.DELETE("", func(ctx *gin.Context) {
+				ctx.JSON(http.StatusOK, gin.H{"message": "Delete Equipment"})
+			})
+		}
+	}
+}

--- a/backend/internal/router/middleware.go
+++ b/backend/internal/router/middleware.go
@@ -1,0 +1,48 @@
+package router
+
+import (
+	"certitrack/internal/config"
+	"certitrack/internal/factories"
+	"certitrack/internal/middleware"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+func setupGlobalMiddleware(r *gin.Engine) {
+	r.Use(gin.Logger())
+	r.Use(gin.Recovery())
+	r.Use(corsMiddleware())
+
+	r.GET("/health", healthCheck)
+}
+
+func corsMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("Access-Control-Allow-Origin", "*")
+		c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+		c.Header("Access-Control-Allow-Headers", "Origin, Content-Type, Authorization")
+
+		if c.Request.Method == "OPTIONS" {
+			c.AbortWithStatus(http.StatusNoContent)
+			return
+		}
+		c.Next()
+	}
+}
+
+func healthCheck(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"status":  "healthy",
+		"service": "certitrack-api",
+		"version": "1.0.0",
+	})
+}
+
+func getAuthMiddleware(db *gorm.DB, cfg *config.Config) gin.HandlerFunc {
+	authFactory := factories.AuthFactoryInstance(db, cfg)
+	authService := authFactory.GetAuthService()
+
+	return middleware.AuthMiddleware(authService)
+}

--- a/backend/internal/router/people.go
+++ b/backend/internal/router/people.go
@@ -1,0 +1,34 @@
+package router
+
+import (
+	"certitrack/internal/config"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+func setupPeopleRoutes(rg *gin.RouterGroup, db *gorm.DB, cfg *config.Config) {
+	people := rg.Group("/people")
+	{
+		people.GET("", func(ctx *gin.Context) {
+			ctx.JSON(http.StatusOK, gin.H{"message": "People"})
+		})
+		people.POST("", func(ctx *gin.Context) {
+			ctx.JSON(http.StatusOK, gin.H{"message": "Create Person"})
+		})
+
+		personRoutes := people.Group("/:id")
+		{
+			personRoutes.GET("", func(ctx *gin.Context) {
+				ctx.JSON(http.StatusOK, gin.H{"message": "Get Person"})
+			})
+			personRoutes.PUT("", func(ctx *gin.Context) {
+				ctx.JSON(http.StatusOK, gin.H{"message": "Update Person"})
+			})
+			personRoutes.DELETE("", func(ctx *gin.Context) {
+				ctx.JSON(http.StatusOK, gin.H{"message": "Delete Person"})
+			})
+		}
+	}
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -1,0 +1,27 @@
+package router
+
+import (
+	"certitrack/internal/config"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+func SetupRouter(db *gorm.DB, cfg *config.Config, router *gin.Engine) {
+	setupGlobalMiddleware(router)
+
+	v1 := router.Group("/api/v1")
+	{
+		setupAuthRoutes(v1, db, cfg)
+
+		protected := v1.Group("")
+		protected.Use(getAuthMiddleware(db, cfg))
+		{
+			setupProtectedAuthRoutes(protected, db, cfg) // auth
+			setupUserRoutes(protected, db, cfg)          // users
+			setupPeopleRoutes(protected, db, cfg)        // people
+			setupEquipmentRoutes(protected, db, cfg)     // equipment
+			setupCertificationRoutes(protected, db, cfg) // certifications
+		}
+	}
+}

--- a/backend/internal/router/users.go
+++ b/backend/internal/router/users.go
@@ -1,0 +1,36 @@
+package router
+
+import (
+	"certitrack/internal/config"
+	"certitrack/internal/middleware"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+func setupUserRoutes(rg *gin.RouterGroup, db *gorm.DB, cfg *config.Config) {
+	users := rg.Group("/users")
+	users.Use(middleware.AdminMiddleware())
+	{
+		users.GET("", func(ctx *gin.Context) {
+			ctx.JSON(http.StatusOK, gin.H{"message": "Users"})
+		})
+		users.POST("", func(ctx *gin.Context) {
+			ctx.JSON(http.StatusOK, gin.H{"message": "Create User"})
+		})
+
+		userRoutes := users.Group("/:id")
+		{
+			userRoutes.GET("", func(ctx *gin.Context) {
+				ctx.JSON(http.StatusOK, gin.H{"message": "Get User"})
+			})
+			userRoutes.PUT("", func(ctx *gin.Context) {
+				ctx.JSON(http.StatusOK, gin.H{"message": "Update User"})
+			})
+			userRoutes.DELETE("", func(ctx *gin.Context) {
+				ctx.JSON(http.StatusOK, gin.H{"message": "Delete User"})
+			})
+		}
+	}
+}


### PR DESCRIPTION
- Split router into separate files per resource (auth, users, people, equipment, certifications)
- Remove redundant comments and improve code organization
- Move route handlers to dedicated files
- Clean up main.go to focus on initialization
- Add descriptive inline comments for route groups